### PR TITLE
change grant_type for user_token

### DIFF
--- a/lib/instamojo/api.rb
+++ b/lib/instamojo/api.rb
@@ -37,7 +37,7 @@ module Instamojo
 
     # Generate user access token
     def user_token(options = {})
-      token(options.merge(credentials('password')))
+      token(options.merge(credentials('client_credentials')))
     end
 
     # Update bank detail to instamojo


### PR DESCRIPTION
- Change grant type for user_token
- Previously we are using password for grant_type, As per V2 documentation of Instamojo it should be 'client_credentials'
- Documentation link - https://docs.instamojo.com/v2/docs/refresh-token-based-authentication
